### PR TITLE
Update simple-router example with async routing and code spite

### DIFF
--- a/examples/simple-router/src/App.js
+++ b/examples/simple-router/src/App.js
@@ -4,19 +4,22 @@ import {Route} from 'mirrorx'
 import Header from './components/Header'
 import Home from './components/Home'
 import About from './components/About'
+import asyncComponent from './asyncComponent'
 
-import Topics from './containers/Topics'
+const Topics = asyncComponent(() => import('./containers/Topics'))
 
-const App = () => (
-  <div>
-    <Header/>
-    <hr/>
+const App = () => {
+  return (
     <div>
-      <Route exact path="/" component={Home}/>
-      <Route path="/about" component={About}/>
-      <Route path="/topics" component={Topics}/>
+      <Header/>
+      <hr/>
+      <div>
+        <Route exact path="/" component={Home}/>
+        <Route path="/about" component={About}/>
+        <Route path="/topics" component={Topics}/>
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default App

--- a/examples/simple-router/src/asyncComponent.js
+++ b/examples/simple-router/src/asyncComponent.js
@@ -1,0 +1,35 @@
+import React from 'react'
+const asyncComponent = loadComponent => (
+  class AsyncComponent extends React.Component {
+    state = {
+      Component: null,
+    }
+
+    componentWillMount () {
+      if (this.hasLoadedComponent()) {
+        return
+      }
+
+      loadComponent()
+        .then(module => module.default)
+        .then((Component) => {
+          this.setState({Component})
+        })
+        .catch((err) => {
+          console.error(`Cannot load component in <AsyncComponent />`)
+          throw err
+        })
+    }
+
+    hasLoadedComponent () {
+      return this.state.Component !== null
+    }
+
+    render () {
+      const {Component} = this.state
+      return (Component) ? <Component {...this.props} /> : null
+    }
+  }
+)
+
+export default asyncComponent

--- a/examples/simple-router/src/containers/Topics.js
+++ b/examples/simple-router/src/containers/Topics.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import mirror, {connect} from 'mirrorx'
+import mirror, { connect, render } from 'mirrorx'
 
 import Topics from '../components/Topics'
 
@@ -14,5 +14,6 @@ mirror.model({
     }
   }
 })
+render()
 
 export default connect(({topics}) => ({topics}))(Topics)


### PR DESCRIPTION
#4 Update simple-router example with async routing and code spite. Using import() in webpack2.  