### PR TITLE
optionally overwrite "addEffect"

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,7 @@
   * [`initialState`](#-optionsinitialstate)
   * [`historyMode`](#-optionshistorymode)
   * [`middlewares`](#-optionsmiddlewares)
+  * [`addEffect`](#-optionsaddeffect)
 * [connect](#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options)
 * [render](#rendercomponent-container-callback)
 * [Router](#router)
@@ -195,7 +196,7 @@ mirror.model({
 })
 ```
 
-Now, `actions.app` will have 2 methods: 
+Now, `actions.app` will have 2 methods:
 
 * `actions.app.add`
 * `actions.app.myEffect`
@@ -448,6 +449,12 @@ For more information, check out the [history](https://github.com/ReactTraining/h
 Specifies a list of [Redux middleware](http://redux.js.org/docs/advanced/Middleware.html).
 
 This option is useful if you want to use some third party middlewares. In this case, you have to [`connect`](#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) without `mapDispatchToProps` specified to get `props.dispatch` method, so you can dispatch actions manually.
+
+#### * `options.addEffect`
+
+* Default: `(effects) => (name, handler) => { effects[name] = handler }`
+
+Presents an option to configure how effects are created.
 
 ### connect([mapStateToProps], [mapDispatchToProps], [mergeProps], [options])
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,5 @@
 import {dispatch} from './middleware'
-import {addEffect} from './effects'
+import {options} from './defaults'
 
 const SEP = '/'
 
@@ -13,7 +13,7 @@ export function addActions(modelName, reducers = {}, effects = {}) {
 
   each(reducers, actionName => {
     // A single-argument function, whose argument is the payload data of a normal redux action,
-    // and also the `data` param of coresponding method defined in model.reducers.
+    // and also the `data` param of corresponding method defined in model.reducers.
     actions[modelName][actionName] = actionCreator(modelName, actionName)
   })
 
@@ -22,7 +22,7 @@ export function addActions(modelName, reducers = {}, effects = {}) {
       throw new Error(`Action name "${effectName}" has been used! Please select another name as effect name!`)
     }
 
-    addEffect(`${modelName}${SEP}${effectName}`, effects[effectName])
+    options.addEffect(`${modelName}${SEP}${effectName}`, effects[effectName])
 
     // Effect is like normal action, except it is handled by mirror middleware
     actions[modelName][effectName] = actionCreator(modelName, effectName)

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,3 +1,5 @@
+import { effects, addEffect } from './effects'
+
 export const options = {
   // global initial state
   // initialState: undefined,
@@ -8,6 +10,10 @@ export const options = {
 
   // A list of the standard Redux middleware
   middlewares: [],
+
+  // An overwrite of the existing effect handler
+  addEffect: addEffect(effects),
+
 }
 
 const historyModes = ['browser', 'hash', 'memory']
@@ -17,6 +23,7 @@ export default function defaults(opts = {}) {
   const {
     historyMode,
     middlewares,
+    addEffect,
   } = opts
 
   if (historyMode && !~historyModes.indexOf(historyMode)) {
@@ -25,6 +32,15 @@ export default function defaults(opts = {}) {
 
   if (middlewares && !Array.isArray(middlewares)) {
     throw new Error(`middlewares "${middlewares}" is invalid, must be an Array!`)
+  }
+
+  if (addEffect) {
+    if (typeof addEffect !== 'function' || typeof addEffect({}) !== 'function') {
+      throw new Error(`addEffect "${addEffect}" is invalid, must be a function that returns a function`)
+    } else {
+      // create effects handler with initial effects object
+      options.addEffect = options.addEffect(effects)
+    }
   }
 
   Object.keys(opts).forEach(key => {

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,6 +1,6 @@
-// Registry of namsspaced effects
+// Registry of namespaced effects
 export const effects = {}
 
-export function addEffect(name, handler) {
+export const addEffect = effects => (name, handler) => {
   effects[name] = handler
 }

--- a/test/defaults.spec.js
+++ b/test/defaults.spec.js
@@ -39,4 +39,19 @@ describe('mirror.defaults', () => {
       })
     }).not.toThrow()
   })
+
+  it('throws if an addEffect is not a function that returns a function', () => {
+    expect(() => {
+      defaults({
+        addEffect: () => true
+      })
+    }).toThrow(/invalid/)
+
+    expect(() => {
+      defaults({
+        addEffect: () => () => true
+      })
+    }).not.toThrow()
+  })
+
 })

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -1,6 +1,6 @@
 import {createStore, applyMiddleware} from 'redux'
 import createMiddleware, {dispatch} from 'middleware'
-import {addEffect} from 'effects'
+import {effects, addEffect} from 'effects'
 
 describe('the middleware', () => {
 
@@ -18,7 +18,7 @@ describe('the middleware', () => {
     }
 
     // register an effect
-    addEffect('myEffect', fn)
+    addEffect(effects)('myEffect', fn)
 
     const store = createStore(reducer, applyMiddleware(createMiddleware()))
 


### PR DESCRIPTION
A step towards adding custom effect middleware. This should enable the ability for users to opt into configuring mirror.js to use sagas for effects (see #35).