### PR TITLE
新增clear函数

### DIFF
--- a/docs/zh/api.md
+++ b/docs/zh/api.md
@@ -489,6 +489,11 @@ mirror.defaults({
 
 > 注意：`connect` 过的组件，如果没有指定 `mapDispatchToProps`，那么该组件的 `props` 会有一个 `dispatch` 方法，Mirror 保留了这个逻辑。这样，你就可以通过 [`mirror.defaults`](#mirrordefaultsoptions) 接口指定一些 middleware，然后拿到 dispatch 方法来使用它们。不过，这是唯一你需要手动 dispatch action 的情况，在其他所有情况下，你都应该使用全局 `actions` 上的方法来 dispatch action。
 
+### clear([modelName])
+`clear`方法主要用于快速的让你的某一个model的state数据恢复到默认的状态下，事实上这样的场景很多，我们可能经常会遭遇到某些当数据与服务端交互完毕之后为了防止下一次使用这个model的时候依然有残留数据，对于ui的呈现来说不是很友好，所以我们需要清理一下state，在这种场景下十分的好用。当然，也并不希望大家滥用这个方法，事实上在大多数的场景下，你可能无须使用到这个函数，在使用这个函数的时候请想清楚你的这部分数据是否有清理的必要。
+
+`clear`函数的实现过程是：在你注册一个model的过程中，我会自动为你注册的model 追加一个全新的reducer，这个reducer的key是`$$mirror$$clear`，所以如果你的log中出现了这样的reducer请不要惊讶，同时也希望你在编写model的时候尽可能的避开使用这个词。
+
 ### render([component], [container], [callback])
 
 Mirror 的 `render` 接口就是加强版的 [`ReactDOM.render`](https://facebook.github.io/react/docs/react-dom.html#render)，它会启动并渲染你的 Mirror app。

--- a/src/actions.js
+++ b/src/actions.js
@@ -7,9 +7,7 @@ export const actions = {}
 
 export function addActions(modelName, reducers = {}, effects = {}) {
 
-  if (Object.keys(effects).length || Object.keys(reducers).length) {
-    actions[modelName] = actions[modelName] || {}
-  }
+  actions[modelName] = actions[modelName] || {}
 
   each(reducers, actionName => {
     // A single-argument function, whose argument is the payload data of a normal redux action,

--- a/src/actions.js
+++ b/src/actions.js
@@ -7,7 +7,7 @@ export const actions = {}
 
 export function addActions(modelName, reducers = {}, effects = {}) {
 
-  if (Object.keys(reducers).length || Object.keys(effects).length) {
+  if (Object.keys(effects).length || Object.keys(reducers).length) {
     actions[modelName] = actions[modelName] || {}
   }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -5,7 +5,7 @@ const SEP = '/'
 
 export const actions = {}
 
-export function addActions(modelName, reducers = {}, effects = {}) {
+export function addActions(modelName, reducers, effects = {}) {
 
   actions[modelName] = actions[modelName] || {}
 
@@ -29,7 +29,7 @@ export function addActions(modelName, reducers = {}, effects = {}) {
   })
 }
 
-export function resolveReducers(modelName, reducers = {}) {
+export function resolveReducers(modelName, reducers) {
   return Object.keys(reducers).reduce((acc, cur) => {
     acc[`${modelName}${SEP}${cur}`] = reducers[cur]
     return acc

--- a/src/clear.js
+++ b/src/clear.js
@@ -1,0 +1,11 @@
+import {actions} from 'actions'
+
+export let mirrorStoreState
+
+export function copyStore(store) {
+  mirrorStoreState = store.getState()
+}
+
+export function clear(modelName) {
+  actions[modelName]['$$mirror$$clear']()
+}

--- a/src/clear.js
+++ b/src/clear.js
@@ -1,4 +1,4 @@
-import {actions} from 'actions'
+import { actions } from 'actions'
 
 export let mirrorStoreState
 

--- a/src/clear.js
+++ b/src/clear.js
@@ -1,4 +1,4 @@
-import { actions } from 'actions'
+import { actions } from './actions'
 
 export let mirrorStoreState
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import render from './render'
 import hook from './hook'
 import Router from './router'
 import defaults from './defaults'
+import { clear } from './clear'
 
 export default {
   model,
@@ -15,6 +16,7 @@ export default {
   defaults,
   connect,
   render,
+  clear,
 
   Router,
   Route,
@@ -33,6 +35,7 @@ export {
   defaults,
   connect,
   render,
+  clear,
 
   Router,
   Route,

--- a/src/model.js
+++ b/src/model.js
@@ -1,8 +1,18 @@
 import { resolveReducers, addActions } from './actions'
+import { mirrorStoreState } from './clear'
 
 export const models = []
 
 export default function model(m) {
+
+
+  const reducers = {
+    $$mirror$$clear(state) {
+      return { ...state, ...mirrorStoreState[m.name] }
+    }
+  }
+
+  m.reducers = { ...m.reducers, ...reducers }
 
   m = validateModel(m)
 

--- a/src/model.js
+++ b/src/model.js
@@ -5,6 +5,7 @@ export const models = []
 
 export default function model(m) {
 
+  m = validateModel(m)
 
   const reducers = {
     $$mirror$$clear(state) {
@@ -12,9 +13,7 @@ export default function model(m) {
     }
   }
 
-  m.reducers = { ...m.reducers, ...reducers }
-
-  m = validateModel(m)
+  m.reducers = { ...m.reducers , ...reducers }
 
   const reducer = getReducer(resolveReducers(m.name, m.reducers), m.initialState)
 

--- a/src/render.js
+++ b/src/render.js
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux'
 import { options } from './defaults'
 import { models } from './model'
 import { store, createStore, replaceReducer } from './store'
+import { copyStore } from './clear'
 
 let started = false
 let Root
@@ -26,6 +27,7 @@ export default function render(component, container, callback) {
 
   } else {
     createStore(models, reducers, initialState, middlewares)
+    copyStore(store)
   }
 
   // Use named function get a proper displayName
@@ -38,6 +40,7 @@ export default function render(component, container, callback) {
   }
 
   started = true
+
 
   global.document && ReactDOM.render(<Root/>, container, callback)
 

--- a/test/clear.spec.js
+++ b/test/clear.spec.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import mirror, { actions, render, connect } from 'index'
+import { clear } from 'clear'
+
+describe('the clear function', () => {
+
+
+  it('should clear', () => {
+
+    const container = document.createElement('div')
+
+    mirror.model({
+      name: 'app',
+      initialState: {
+        count: 0
+      },
+      reducers: {
+        increment(state) {
+          return { ...state, count: state.count + 1 }
+        }
+      }
+    })
+
+    /* eslint react/prop-types: 0 */
+    const Comp = props => <div id="app" onClick={actions.app.increment}>{props.count}</div>
+
+    const App = connect(({ app }) => app)(Comp)
+
+    render(<App/>, container)
+
+    const app = container.querySelector('#app')
+
+    expect(app.textContent).toEqual('0')
+
+    // call the action
+    actions.app.increment()
+
+    expect(app.textContent).toEqual('1')
+
+    actions.app.increment()
+
+    expect(app.textContent).toEqual('2')
+
+    clear('app')
+
+    expect(app.textContent).toEqual('0')
+
+  })
+
+
+})

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -48,7 +48,7 @@ describe('mirror.model', () => {
 
   it('models should be an array', () => {
     const mirror = require('index')
-    const { models } = require('model')
+    const {models} = require('model')
 
     expect(models).toBeInstanceOf(Array)
 
@@ -86,7 +86,8 @@ describe('mirror.model', () => {
     expect(() => {
       mirror.model({
         name: 'app',
-        reducers: () => {}
+        reducers: () => {
+        }
       })
     }).toThrow(errorReg)
 
@@ -119,7 +120,8 @@ describe('mirror.model', () => {
     expect(() => {
       mirror.model({
         name: 'app',
-        effects: () => {}
+        effects: () => {
+        }
       })
     }).toThrow(errorReg)
 
@@ -129,39 +131,6 @@ describe('mirror.model', () => {
         reducers: {}
       }).not.toThrow()
     })
-  })
-
-  it('do not add actions if reducers and effects are empty', () => {
-    const mirror = require('index')
-    const { actions } = mirror
-
-    mirror.model({
-      name: 'model1'
-    })
-
-    expect(actions).toEqual({})
-
-    mirror.model({
-      name: 'model2',
-      reducers: {}
-    })
-
-    expect(actions).toEqual({})
-
-    mirror.model({
-      name: 'model3',
-      effects: {}
-    })
-
-    expect(actions).toEqual({})
-
-    mirror.model({
-      name: 'model4',
-      effects: {},
-      reducers: {}
-    })
-
-    expect(actions).toEqual({})
   })
 
   it('throws if effect name is duplicated with action name', () => {
@@ -176,7 +145,8 @@ describe('mirror.model', () => {
           }
         },
         effects: {
-          async add() {}
+          async add() {
+          }
         }
       })
     }).toThrow(/Please select another name as effect name/)
@@ -184,9 +154,10 @@ describe('mirror.model', () => {
 
   it('should ignore non-function entries in reducers and effects', () => {
     const mirror = require('index')
-    const { actions } = mirror
+    const {actions} = mirror
 
-    const fn = () => {}
+    const fn = () => {
+    }
 
     mirror.model({
       name: 'model1',
@@ -195,7 +166,7 @@ describe('mirror.model', () => {
       }
     })
 
-    expect(actions).toEqual({})
+    expect(actions.model1.a).toEqual(undefined)
 
     mirror.model({
       name: 'model2',
@@ -204,7 +175,7 @@ describe('mirror.model', () => {
       }
     })
 
-    expect(actions).toEqual({})
+    expect(actions.model2.b).toEqual(undefined)
 
     mirror.model({
       name: 'model3',
@@ -219,6 +190,6 @@ describe('mirror.model', () => {
     })
 
     expect(actions.model3).toBeInstanceOf(Object)
-    expect(Object.keys(actions.model3)).toEqual(['add', 'plus'])
+    expect(Object.keys(actions.model3)).toEqual(['add', '$$mirror$$clear', 'plus'])
   })
 })

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -48,7 +48,7 @@ describe('mirror.model', () => {
 
   it('models should be an array', () => {
     const mirror = require('index')
-    const {models} = require('model')
+    const { models } = require('model')
 
     expect(models).toBeInstanceOf(Array)
 
@@ -154,7 +154,7 @@ describe('mirror.model', () => {
 
   it('should ignore non-function entries in reducers and effects', () => {
     const mirror = require('index')
-    const {actions} = mirror
+    const { actions } = mirror
 
     const fn = () => {
     }


### PR DESCRIPTION
该函数的用途主要是  让某一个model 的state 直接清空，恢复到初始状态


使用场景：

在我的业务场景中存在一个   新增商品分类的功能 ， 这个功能体现形式是以一个弹出层的方式来进行新增。  在我的model设置中，自然而然的为这个功能独立的  设立了一个model 叫做category ，内部的state包含 商品分类的基础属性（这里我们假设不止一个字段），同时具备一个往服务端发送一个新增请求的effect ， 当我在执行完新增商品分类之后，在页面上我的弹出层会自动关闭，而如果我紧接着再次打开新增的弹出层，会发现数据停留在上一次新增时我输入的数据， 这里理应在每次打开新增分类的弹出层的时候都去清空一下商品分类model的state数据，其实在很多场景下斗会存在这个需求，而如果每一个model我都去手写这么一个函数，无疑是不太情愿的，所以提供了clear 快捷的、一次性的，直接让某一个model的state直接恢复到初始状态，希望采纳